### PR TITLE
Make non-breaking-space regex Unicode aware

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -282,7 +282,7 @@ class Bot {
       const fromGuild = message.guild;
       const nickname = Bot.getDiscordNicknameOnServer(author, fromGuild);
       let text = this.parseText(message);
-      let displayUsername = nickname.replace(/(.{1})/g,"$1\u200B");
+      let displayUsername = nickname.replace(/(.{1})/gu,"$1\u200B");
       if (this.ircNickColor) {
         const colorIndex = (nickname.charCodeAt(0) + nickname.length) % NICK_COLORS.length;
         displayUsername = irc.colors.wrap(NICK_COLORS[colorIndex], displayUsername);


### PR DESCRIPTION
This prevents Unicode characters which are encoded as multiple bytes from being mangled.